### PR TITLE
return tokenize instance

### DIFF
--- a/jquery.tokenize.js
+++ b/jquery.tokenize.js
@@ -526,13 +526,14 @@
             options = {};
         }
 
+        var obj;
         this.each(function(){
-            var obj = new $.tokenize($.extend({}, $.fn.tokenize.defaults, options));
+            obj = new $.tokenize($.extend({}, $.fn.tokenize.defaults, options));
             obj.init($(this));
             $(this).data(DATA, obj);
         });
 
-        return this;
+        return obj;
 
     };
 


### PR DESCRIPTION
This way I can do stuff with my select afterwards. For example, update selected via my own JS. So now:

```
var tokenizeInstance = $('select').tokenize();
tokenizeInstance.tokenAdd(value, text, true);
tokenizeInstance.updatePlaceholder();
```

Didn't see a way to do this before. Not sure if this breaks anything since I couldn't determine how the original return value was useful.
